### PR TITLE
docs(readme): delete apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ const App = () => {
     container: containerRef,
     url: '/my-server/audio.ogg',
     waveColor: 'purple',
-    height: 100',
+    height: 100,
   })
 
   const onPlayPause = () => {


### PR DESCRIPTION
Hey!

I was trying the example code on the README.md and noticed there was a minor typo `'`.