### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import { useRef } from 'react'
 import { useWavesurfer } from '@wavesurfer/react'
 
 const App = () => {
-  const containerRef = useRef()
+  const containerRef = useRef(null)
 
   const { wavesurfer, isReady, isPlaying, currentTime } = useWavesurfer({
     container: containerRef,


### PR DESCRIPTION
WHen using TypeScript I couldn't get my containerRef to work as it was not of the expected format `RefObject<HTMLElement>`. I 

RefObject expected either HTMLElement or null:
```ts
    interface RefObject<T> {
        /**
         * The current value of the ref.
         */
        readonly current: T | null;
    }
```

Calling useRef without initial arguments creates the ref as `MutableRefObject<T | undefined>` which is incompatible.