### PR TITLE
creates a hasFinished state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,6 +70,7 @@ function useWavesurferState(wavesurfer: WaveSurfer | null): {
 } {
   const [isReady, setIsReady] = useState<boolean>(false)
   const [isPlaying, setIsPlaying] = useState<boolean>(false)
+  const [hasFinished, setHasFinished] = useState<boolean>(false)
   const [currentTime, setCurrentTime] = useState<number>(0)
 
   useEffect(() => {
@@ -85,7 +86,12 @@ function useWavesurferState(wavesurfer: WaveSurfer | null): {
       wavesurfer.on('ready', () => {
         setIsReady(true)
         setIsPlaying(false)
+        setHasFinished(false)
         setCurrentTime(0)
+      }),
+
+      wavesurfer.on('finish', () => {
+        setHasFinished(true)
       }),
 
       wavesurfer.on('play', () => {
@@ -115,9 +121,10 @@ function useWavesurferState(wavesurfer: WaveSurfer | null): {
     () => ({
       isReady,
       isPlaying,
+      hasFinished,
       currentTime,
     }),
-    [isPlaying, currentTime, isReady],
+    [isPlaying, hasFinished, currentTime, isReady],
   )
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -208,7 +208,7 @@ export default WavesurferPlayer
  * const App = () => {
  *   const containerRef = useRef<HTMLDivElement | null>(null)
  *
- *   const { wavesurfer, isReady, isPlaying, currentTime } = useWavesurfer({
+ *   const { wavesurfer, isReady, isPlaying, hasFinished, currentTime } = useWavesurfer({
  *     container: containerRef,
  *     url: '/my-server/audio.ogg',
  *     waveColor: 'purple',


### PR DESCRIPTION
It doesn't look like it is possible to get the 'finish' event when you are using WaveSurfer as a hook. This PR creates a State for whether the 'finish' event has fired. It is reset when 'ready' event is fired. This makes it possible to have useEffect related to this event.

There maybe a better way of doing this... but this seems to work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new playback state indicator, `hasFinished`, to track audio playback completion.
	- Updated the app to reflect the new playback state in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->