### PR TITLE
Allow react18 too

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,14 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js tests",
     "test:ci": "yarn test --ci --silent --coverage --json --watchAll=false --testLocationInResults --outputFile=report.json",
     "serve": "npx live-server --port=3030 --no-browser --ignore='.*,src,tests'",
+    "prepare": "yarn build",
     "prepublishOnly": "yarn build"
   },
   "author": "katspaugh",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "react": "^18.2.0 || ^19.0.0",
-    "wavesurfer.js": ">=7.8.11"
+    "wavesurfer.js": ">=7.7.14"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "katspaugh",
   "license": "BSD-3-Clause",
   "peerDependencies": {
-    "react": "^19.0.0",
+    "react": "^18.2.0 || ^19.0.0",
     "wavesurfer.js": ">=7.8.11"
   },
   "devDependencies": {


### PR DESCRIPTION
This allows to use the library on React 18 as well #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Update**
  - Expanded React version compatibility to support both React 18.2.0 and React 19.x versions
  - Broadened acceptable versions for wavesurfer.js to include versions starting from 7.7.14
- **New Features**
  - Added a prepare script to run a build command before publishing the package
<!-- end of auto-generated comment: release notes by coderabbit.ai -->