### PR TITLE
fix: Add height=100% to container if height is set to auto

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -190,8 +190,12 @@ const WavesurferPlayer = memo((props: WavesurferProps): ReactElement => {
   const wavesurfer = useWavesurferInstance(containerRef, options)
   useWavesurferEvents(wavesurfer, events)
 
+  const style = {
+    ...(options.height == 'auto' && { height: '100%' }),
+  }
+
   // Create a container div
-  return <div ref={containerRef} />
+  return <div style={style} ref={containerRef} />
 })
 
 /**


### PR DESCRIPTION
When passing `height='auto'` to the WavesurferPlayer, it is not actually able to take automatically adjust height because the container defined in `WavesurferPlayer` doesn't have a height.

So realistically, someone who uses `WavesurferPlayer` would expect the player to take the height of its player container.

i.e.

```
<div style={{height: "500px"}}> //  I expect Wavesufer to take the height of this div
    <WavesurferPlayer height='auto'/>
</div>

```